### PR TITLE
Add support for matching comments containining a Markdown-formatted "Code Review"

### DIFF
--- a/src/main/java/com/skiwi/githubhooksechatservice/mvc/beans/tasks/CommentsScanTask.java
+++ b/src/main/java/com/skiwi/githubhooksechatservice/mvc/beans/tasks/CommentsScanTask.java
@@ -15,13 +15,13 @@ import com.skiwi.githubhooksechatservice.stackapi.StackComments;
 import com.skiwi.githubhooksechatservice.stackapi.StackExchangeComment;
 
 public class CommentsScanTask implements Runnable {
-    private static final Logger logger = LogManager.getLogger(CommentsScanTask.class);
-    
-    private Instant nextFetch = Instant.now();
-    private long lastComment;
-    private long fromDate;
-    private int remainingQuota;
-    
+	private static final Logger logger = LogManager.getLogger(CommentsScanTask.class);
+	
+	private Instant nextFetch = Instant.now();
+	private long lastComment;
+	private long fromDate;
+	private int remainingQuota;
+	
 	private final WebhookParameters params = WebhookParameters.toRoom("8595");
 	private final WebhookParameters debug = WebhookParameters.toRoom("20298");
 	private final WebhookParameters programmers = WebhookParameters.toRoom("21");
@@ -31,73 +31,73 @@ public class CommentsScanTask implements Runnable {
 
 	private ChatBot chatBot;
 	
-    public CommentsScanTask(StackExchangeAPIBean stackAPI, ChatBot chatBot) {
+	public CommentsScanTask(StackExchangeAPIBean stackAPI, ChatBot chatBot) {
 		this.stackAPI = stackAPI;
 		this.chatBot = chatBot;
 	}
 
 	private boolean isInterestingComment(StackExchangeComment comment) {
 		String commentText = comment.getBodyMarkdown().toLowerCase();
-    	return commentText.contains("code review") || commentText.contains("codereview");
+			return commentText.contains("code review") || commentText.contains("codereview");
 	}
 
 	@Override
-    public void run() {
-    	if (!Instant.now().isAfter(nextFetch)) {
-    		return;
-    	}
+	public void run() {
+		if (!Instant.now().isAfter(nextFetch)) {
+			return;
+		}
 
-    	try {
-    		StackComments comments = stackAPI.fetchComments("stackoverflow", fromDate);
-    		int currentQuota = comments.getQuotaRemaining();
-    		if (currentQuota > remainingQuota && fromDate != 0) {
+		try {
+			StackComments comments = stackAPI.fetchComments("stackoverflow", fromDate);
+			int currentQuota = comments.getQuotaRemaining();
+			if (currentQuota > remainingQuota && fromDate != 0) {
 				chatBot.postMessage(debug, Instant.now() + " Quota has been reset. Was " + remainingQuota + " is now " + currentQuota);
-    		}
-    		remainingQuota = currentQuota;
-    		List<StackExchangeComment> items = comments.getItems();
-    		if (items != null) {
-    			if (items.size() >= 100) {
-    				chatBot.postMessage(debug, Instant.now() + " Warning: Retrieved 100 comments. Might have missed some.");
-    			}
-    			
-    			long previousLastComment = lastComment;
-        		Collections.reverse(items);
-    			for (StackExchangeComment comment : items) {
-    				if (comment.getCommentId() <= previousLastComment) {
-    					continue;
-    				}
-    				lastComment = Math.max(comment.getCommentId(), lastComment);
-    				fromDate = Math.max(comment.getCreationDate(), fromDate);
-    				if (isInterestingComment(comment)) {
-    					chatBot.postMessage(params, comment.getLink());
-    				}
-    				float programmersCertainty = CommentClassification.calcInterestingLevelProgrammers(comment);
-    				
-    				if (programmersCertainty >= CommentClassification.REAL) {
-    					chatBot.postMessage(programmers, comment.getLink());
-    				}
-    				if (programmersCertainty >= CommentClassification.DEBUG) {
-    					chatBot.postMessage(debug, "Certainty level " + programmersCertainty);
-    					chatBot.postMessage(debug, comment.getLink());
-    				}
-    				
-    				float softwareCertainty = CommentClassification.calcInterestingLevelSoftwareRecs(comment);
-    				
-    				if (softwareCertainty >= CommentClassification.REAL) {
-    					chatBot.postMessage(softwareRecs, comment.getLink());
-    				}
-    			}
-                items.clear();
-            }
-            if (comments.getBackoff() != 0) {
-                nextFetch = Instant.now().plusSeconds(comments.getBackoff() + 10);
-                chatBot.postMessage(debug, Instant.now() + " Next fetch: " + nextFetch + " because of backoff " + comments.getBackoff());
-            }
-    	} catch (Exception e) {
-    		logger.error("Error retrieving comments", e);
-    		chatBot.postMessage(debug, Instant.now() + " Exception in comment task " + e);
-    		return;
-    	}
-    }
+			}
+			remainingQuota = currentQuota;
+			List<StackExchangeComment> items = comments.getItems();
+			if (items != null) {
+				if (items.size() >= 100) {
+					chatBot.postMessage(debug, Instant.now() + " Warning: Retrieved 100 comments. Might have missed some.");
+				}
+				
+				long previousLastComment = lastComment;
+				Collections.reverse(items);
+				for (StackExchangeComment comment : items) {
+					if (comment.getCommentId() <= previousLastComment) {
+						continue;
+					}
+					lastComment = Math.max(comment.getCommentId(), lastComment);
+					fromDate = Math.max(comment.getCreationDate(), fromDate);
+					if (isInterestingComment(comment)) {
+						chatBot.postMessage(params, comment.getLink());
+					}
+					float programmersCertainty = CommentClassification.calcInterestingLevelProgrammers(comment);
+					
+					if (programmersCertainty >= CommentClassification.REAL) {
+						chatBot.postMessage(programmers, comment.getLink());
+					}
+					if (programmersCertainty >= CommentClassification.DEBUG) {
+						chatBot.postMessage(debug, "Certainty level " + programmersCertainty);
+						chatBot.postMessage(debug, comment.getLink());
+					}
+					
+					float softwareCertainty = CommentClassification.calcInterestingLevelSoftwareRecs(comment);
+					
+					if (softwareCertainty >= CommentClassification.REAL) {
+						chatBot.postMessage(softwareRecs, comment.getLink());
+					}
+				}
+				items.clear();
+			}
+			if (comments.getBackoff() != 0) {
+				nextFetch = Instant.now().plusSeconds(comments.getBackoff() + 10);
+				chatBot.postMessage(debug, Instant.now() + " Next fetch: " + nextFetch + " because of backoff " + comments.getBackoff());
+			}
+		} catch (Exception e) {
+			logger.error("Error retrieving comments", e);
+			chatBot.postMessage(debug, Instant.now() + " Exception in comment task " + e);
+			return;
+		}
+	}
 
 }

--- a/src/main/java/com/skiwi/githubhooksechatservice/mvc/beans/tasks/CommentsScanTask.java
+++ b/src/main/java/com/skiwi/githubhooksechatservice/mvc/beans/tasks/CommentsScanTask.java
@@ -31,7 +31,11 @@ public class CommentsScanTask implements Runnable {
 
 	private ChatBot chatBot;
 	
-	private Pattern interestingComment = Pattern.compile("[*`_]{,2}code[*`_]{,2}\s*[*`_]{,2}review[*`_]{,2}", Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CASE);
+	/**
+	 * If any substring of a comment matches this pattern, it's probably interesting.<br>
+	 * No need for case-insensitivity since the comment is already lower-cased by the time it's being compared.
+	 */
+	private Pattern interestingComment = Pattern.compile("[*`_]{,2}code[*`_]{,2}\s*[*`_]{,2}review[*`_]{,2}");
 	
 	public CommentsScanTask(StackExchangeAPIBean stackAPI, ChatBot chatBot) {
 		this.stackAPI = stackAPI;
@@ -39,10 +43,11 @@ public class CommentsScanTask implements Runnable {
 	}
 
 	private boolean isInterestingComment(StackExchangeComment comment) {
-		String commentText = comment.getBodyMarkdown().toLowerCase();
+		String commentText = comment.getBodyMarkdown().toLowerCase(Locale.ENGLISH);
 		return interestingComment.matcher(commentText).find(0);
 		// We're using `find()` instead of `matches()` because it can occur anywhere and we don't wanna reject if we can't match the whole comment
 		// See https://docs.oracle.com/javase/8/docs/api/java/util/regex/Matcher.html#matches-- and #find-int- for more information
+		// (and we're using find(0) to make sure it searches from the start, not somewhere in the middle)
 	}
 
 	@Override

--- a/src/main/java/com/skiwi/githubhooksechatservice/mvc/beans/tasks/CommentsScanTask.java
+++ b/src/main/java/com/skiwi/githubhooksechatservice/mvc/beans/tasks/CommentsScanTask.java
@@ -31,6 +31,8 @@ public class CommentsScanTask implements Runnable {
 
 	private ChatBot chatBot;
 	
+	private Pattern interestingComment = Pattern.compile("[*`_]{,2}code[*`_]{,2}\s*[*`_]{,2}review[*`_]{,2}", Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CASE);
+	
 	public CommentsScanTask(StackExchangeAPIBean stackAPI, ChatBot chatBot) {
 		this.stackAPI = stackAPI;
 		this.chatBot = chatBot;
@@ -38,7 +40,9 @@ public class CommentsScanTask implements Runnable {
 
 	private boolean isInterestingComment(StackExchangeComment comment) {
 		String commentText = comment.getBodyMarkdown().toLowerCase();
-			return commentText.contains("code review") || commentText.contains("codereview");
+		return interestingComment.matcher(commentText).find(0);
+		// We're using `find()` instead of `matches()` because it can occur anywhere and we don't wanna reject if we can't match the whole comment
+		// See https://docs.oracle.com/javase/8/docs/api/java/util/regex/Matcher.html#matches-- and #find-int- for more information
 	}
 
 	@Override

--- a/src/main/java/com/skiwi/githubhooksechatservice/mvc/beans/tasks/CommentsScanTask.java
+++ b/src/main/java/com/skiwi/githubhooksechatservice/mvc/beans/tasks/CommentsScanTask.java
@@ -3,6 +3,8 @@ package com.skiwi.githubhooksechatservice.mvc.beans.tasks;
 import java.time.Instant;
 import java.util.Collections;
 import java.util.List;
+import java.util.Locale;
+import java.util.regex.*;
 
 import org.apache.log4j.LogManager;
 import org.apache.log4j.Logger;
@@ -33,9 +35,10 @@ public class CommentsScanTask implements Runnable {
 	
 	/**
 	 * If any substring of a comment matches this pattern, it's probably interesting.<br>
-	 * No need for case-insensitivity since the comment is already lower-cased by the time it's being compared.
+	 * No need for case-insensitivity since the comment is already lower-cased by the time it's being compared.<br>
+	 * It wouldn't do any harm, though.
 	 */
-	private Pattern interestingComment = Pattern.compile("[*`_]{,3}code[*`_]{,3}\\s*[*`_]{,3}review[*`_]{,3}");
+	private Pattern interestingComment = Pattern.compile("[*`_]{0,3}code[*`_]{0,3}\\s*[*`_]{0,3}review[*`_]{0,3}");
 	
 	public CommentsScanTask(StackExchangeAPIBean stackAPI, ChatBot chatBot) {
 		this.stackAPI = stackAPI;

--- a/src/main/java/com/skiwi/githubhooksechatservice/mvc/beans/tasks/CommentsScanTask.java
+++ b/src/main/java/com/skiwi/githubhooksechatservice/mvc/beans/tasks/CommentsScanTask.java
@@ -35,7 +35,7 @@ public class CommentsScanTask implements Runnable {
 	 * If any substring of a comment matches this pattern, it's probably interesting.<br>
 	 * No need for case-insensitivity since the comment is already lower-cased by the time it's being compared.
 	 */
-	private Pattern interestingComment = Pattern.compile("[*`_]{,2}code[*`_]{,2}\s*[*`_]{,2}review[*`_]{,2}");
+	private Pattern interestingComment = Pattern.compile("[*`_]{,3}code[*`_]{,3}\s*[*`_]{,3}review[*`_]{,3}");
 	
 	public CommentsScanTask(StackExchangeAPIBean stackAPI, ChatBot chatBot) {
 		this.stackAPI = stackAPI;

--- a/src/main/java/com/skiwi/githubhooksechatservice/mvc/beans/tasks/CommentsScanTask.java
+++ b/src/main/java/com/skiwi/githubhooksechatservice/mvc/beans/tasks/CommentsScanTask.java
@@ -35,7 +35,7 @@ public class CommentsScanTask implements Runnable {
 	 * If any substring of a comment matches this pattern, it's probably interesting.<br>
 	 * No need for case-insensitivity since the comment is already lower-cased by the time it's being compared.
 	 */
-	private Pattern interestingComment = Pattern.compile("[*`_]{,3}code[*`_]{,3}\s*[*`_]{,3}review[*`_]{,3}");
+	private Pattern interestingComment = Pattern.compile("[*`_]{,3}code[*`_]{,3}\\s*[*`_]{,3}review[*`_]{,3}");
 	
 	public CommentsScanTask(StackExchangeAPIBean stackAPI, ChatBot chatBot) {
 		this.stackAPI = stackAPI;

--- a/src/test/java/com/skiwi/githubhooksechatservice/mvc/beans/tasks/CommentsScanTaskTest.java
+++ b/src/test/java/com/skiwi/githubhooksechatservice/mvc/beans/tasks/CommentsScanTaskTest.java
@@ -25,7 +25,7 @@ public class CommentsScanTaskTest {
 		}
 		for (String match : shouldMatch)
 			assertTrue(match + " should be interesting, but isn't!", isInterestingComment(match));
-		for (String match : shouldMatch)
+		for (String match : shouldntMatch)
 			assertFalse(match + " shouldn't be interesting, but is!", isInterestingComment(match));
 	}
 }

--- a/src/test/java/com/skiwi/githubhooksechatservice/mvc/beans/tasks/CommentsScanTaskTest.java
+++ b/src/test/java/com/skiwi/githubhooksechatservice/mvc/beans/tasks/CommentsScanTaskTest.java
@@ -1,0 +1,13 @@
+import static org.junit.Assert.*;
+
+public class CommentsScanTaskTest {
+  private Pattern interestingComment = Pattern.compile("[*`_]{,2}code[*`_]{,2}\s*[*`_]{,2}review[*`_]{,2}");
+	
+	private boolean isInterestingComment(String comment) {
+		String commentText = comment.toLowerCase(Locale.ENGLISH);
+		return interestingComment.matcher(commentText).find(0);
+		// We're using `find()` instead of `matches()` because it can occur anywhere and we don't wanna reject if we can't match the whole comment
+		// See https://docs.oracle.com/javase/8/docs/api/java/util/regex/Matcher.html#matches-- and #find-int- for more information
+		// (and we're using find(0) to make sure it searches from the start, not somewhere in the middle)
+	}
+}

--- a/src/test/java/com/skiwi/githubhooksechatservice/mvc/beans/tasks/CommentsScanTaskTest.java
+++ b/src/test/java/com/skiwi/githubhooksechatservice/mvc/beans/tasks/CommentsScanTaskTest.java
@@ -1,31 +1,33 @@
-import static org.junit.Assert.*;
+import java.util.regex.*;
+import java.util.*;
 
 public class CommentsScanTaskTest {
-	private Pattern interestingComment = Pattern.compile("[*`_]{,3}code[*`_]{,3}\s*[*`_]{,3}review[*`_]{,3}");
+	private static Pattern interestingComment = Pattern.compile("[\\*`_]{0,3}code[\\*`_]{0,3}\\s*[\\*`_]{0,3}review[\\*`_]{0,3}");
 	
 	private static boolean isInterestingComment(String comment) {
 		String commentText = comment.toLowerCase(Locale.ENGLISH);
 		return interestingComment.matcher(commentText).find(0);
 	}
 	
-	public void test() throws Exception {
+	public static void test() throws Exception {
 		String[] shouldMatch = {
 			"This is a demo comment containing the text Code Review.",
 			"This is another with a formatted _Code_ **Review**",
 			"This isn't valid Markdown, but *_Code Review*_'s Duga don't care.",
 			"Then, of course, CodeReview and coderevIEW and COde       REView should also all be matched",
-			"This is a comment about how you need a code review!"
+			"This is a comment about how you need a code review!",
+			"This is testing that that great site, Code Review, is matched"
 		};
 		String[] shouldntMatch = {
 			"This is a comment without the C/R words in it.",
 			"This is Co*de Review* with formatting in the middle, which isn't matched by design",
 			"[Code](http://google.com) Review definitely should not though.",
 			"This is a comment about apologizing for code and review.",
-			"This is testing that that great site, Code Review, is matched"
-		}
+			"This talks about code, review, but shouldn't be matched."
+		};
 		for (String match : shouldMatch)
-			assertTrue(match + " should be interesting, but isn't!", isInterestingComment(match));
+			assertTrue("'" + match + "' should be interesting, but isn't!", isInterestingComment(match));
 		for (String match : shouldntMatch)
-			assertFalse(match + " shouldn't be interesting, but is!", isInterestingComment(match));
+			assertFalse("'" + match + "' shouldn't be interesting, but is!", isInterestingComment(match));
 	}
 }

--- a/src/test/java/com/skiwi/githubhooksechatservice/mvc/beans/tasks/CommentsScanTaskTest.java
+++ b/src/test/java/com/skiwi/githubhooksechatservice/mvc/beans/tasks/CommentsScanTaskTest.java
@@ -1,13 +1,31 @@
 import static org.junit.Assert.*;
 
 public class CommentsScanTaskTest {
-  private Pattern interestingComment = Pattern.compile("[*`_]{,2}code[*`_]{,2}\s*[*`_]{,2}review[*`_]{,2}");
+	private Pattern interestingComment = Pattern.compile("[*`_]{,3}code[*`_]{,3}\s*[*`_]{,3}review[*`_]{,3}");
 	
-	private boolean isInterestingComment(String comment) {
+	private static boolean isInterestingComment(String comment) {
 		String commentText = comment.toLowerCase(Locale.ENGLISH);
 		return interestingComment.matcher(commentText).find(0);
-		// We're using `find()` instead of `matches()` because it can occur anywhere and we don't wanna reject if we can't match the whole comment
-		// See https://docs.oracle.com/javase/8/docs/api/java/util/regex/Matcher.html#matches-- and #find-int- for more information
-		// (and we're using find(0) to make sure it searches from the start, not somewhere in the middle)
+	}
+	
+	public void test() throws Exception {
+		String[] shouldMatch = {
+			"This is a demo comment containing the text Code Review.",
+			"This is another with a formatted _Code_ **Review**",
+			"This isn't valid Markdown, but *_Code Review*_'s Duga don't care.",
+			"Then, of course, CodeReview and coderevIEW and COde       REView should also all be matched",
+			"This is a comment about how you need a code review!"
+		};
+		String[] shouldntMatch = {
+			"This is a comment without the C/R words in it.",
+			"This is Co*de Review* with formatting in the middle, which isn't matched by design",
+			"[Code](http://google.com) Review definitely should not though.",
+			"This is a comment about apologizing for code and review.",
+			"This is testing that that great site, Code Review, is matched"
+		}
+		for (String match : shouldMatch)
+			assertTrue(match + " should be interesting, but isn't!", isInterestingComment(match));
+		for (String match : shouldMatch)
+			assertFalse(match + " shouldn't be interesting, but is!", isInterestingComment(match));
 	}
 }

--- a/src/test/java/com/skiwi/githubhooksechatservice/mvc/beans/tasks/CommentsScanTaskTest.java
+++ b/src/test/java/com/skiwi/githubhooksechatservice/mvc/beans/tasks/CommentsScanTaskTest.java
@@ -1,6 +1,8 @@
 import java.util.regex.*;
 import java.util.*;
 
+import static org.junit.Assert.*;
+
 public class CommentsScanTaskTest {
 	private static Pattern interestingComment = Pattern.compile("[\\*`_]{0,3}code[\\*`_]{0,3}\\s*[\\*`_]{0,3}review[\\*`_]{0,3}");
 	


### PR DESCRIPTION
For example, if someone were to emphasize that `it's _Code_ Review, not _Prose_ Review`, Duga's still gonna pick it up.

There's also some unit tests. More may be necessary, but I think they cover just about everything.