### PR TITLE
Update io.spring.dependency-management version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ buildscript {
 }
 
 plugins {
-    id "io.spring.dependency-management" version "0.4.0.RELEASE"
+    id "io.spring.dependency-management" version "1.0.10.RELEASE"
 }
 
 version "0.3-SNAPSHOT"


### PR DESCRIPTION
This allowed me to build inside a software container and appears to be the minimal change required.